### PR TITLE
Update credentials setup for SPADS service

### DIFF
--- a/roles/spads/tasks/installSPADS.yaml
+++ b/roles/spads/tasks/installSPADS.yaml
@@ -96,19 +96,10 @@
 
 - debug: var=out.stdout_lines
 
-- name: Drop SFTP_PASSWORD to .bashrc
-  ansible.builtin.lineinfile:
-    path: /home/{{ spads_username }}/.bashrc
-    regexp: '^export SFTP_PASSWORD='
-    state: absent
-
-- name: Drop SFTP_LOGIN to .bashrc
-  ansible.builtin.lineinfile:
-    path: /home/{{ spads_username }}/.bashrc
-    regexp: '^export SFTP_LOGIN='
-    state: absent
-
 - name: Setup secrets.env file
   ansible.builtin.template:
     src: "secrets.env.j2"
     dest: "{{ spads_install_path }}/secrets.env"
+  # let's not print secrets in the log
+  no_log: true
+  diff: no

--- a/roles/spads/tasks/installSPADS.yaml
+++ b/roles/spads/tasks/installSPADS.yaml
@@ -96,14 +96,19 @@
 
 - debug: var=out.stdout_lines
 
-- name: Add SFTP_PASSWORD to .bashrc
+- name: Drop SFTP_PASSWORD to .bashrc
   ansible.builtin.lineinfile:
     path: /home/{{ spads_username }}/.bashrc
     regexp: '^export SFTP_PASSWORD='
-    line: 'export SFTP_PASSWORD="{{ sftp_password }}"'
+    state: absent
 
-- name: Add SFTP_LOGIN to .bashrc
+- name: Drop SFTP_LOGIN to .bashrc
   ansible.builtin.lineinfile:
     path: /home/{{ spads_username }}/.bashrc
     regexp: '^export SFTP_LOGIN='
-    line: 'export SFTP_LOGIN="{{ sftp_login }}"'
+    state: absent
+
+- name: Setup secrets.env file
+  ansible.builtin.template:
+    src: "secrets.env.j2"
+    dest: "{{ spads_install_path }}/secrets.env"

--- a/roles/spads/templates/secrets.env.j2
+++ b/roles/spads/templates/secrets.env.j2
@@ -1,0 +1,5 @@
+SPADS_LOBBY_LOGIN={{ spads_lobbyLogin | quote }}
+SPADS_LOBBY_PASSWORD={{ spads_lobbyPassword | quote }}
+SPADS_REGISTRATION_EMAIL={{ spads_lobbyPassword | quote }}
+SFTP_LOGIN={{ sftp_login | quote }}
+SFTP_PASSWORD={{ sftp_password | quote }}

--- a/roles/spads/templates/spads.service.j2
+++ b/roles/spads/templates/spads.service.j2
@@ -11,6 +11,7 @@ Restart=on-failure
 RestartSec=60s
 User={{ spads_username }}
 WorkingDirectory={{ spads_install_path }}/etc
+EnvironmentFile={{ spads_install_path }}/secrets.env
 ExecStart={{ spads_install_path }}/etc/spads_cluster_launcher.sh
 # TODO: Type=notify-reload is available only since systemd v253 :(
 ExecReload=/bin/kill -HUP $MAINPID

--- a/roles/spads/templates/spads_cluster_launcher.sh.j2
+++ b/roles/spads/templates/spads_cluster_launcher.sh.j2
@@ -44,11 +44,11 @@
 # Dont forget the trailing backslashes at the ends of lines!
 
 perl ../spads.pl spads_cluster.conf \
-	CMD_lobbyLogin={{ spads_lobbyLogin }} \
+	CMD_lobbyLogin=$SPADS_LOBBY_LOGIN \
 	CMD_spadsChannel={{ spads_channel }} \
-	CMD_lobbyPassword={{ spads_lobbyPassword }} \
+	CMD_lobbyPassword=$SPADS_LOBBY_PASSWORD \
 	CMD_lobbyHost={{ spads_lobbyHost }} \
-	CMD_registrationEmail={{ spads_registrationEmail }} \
+	CMD_registrationEmail=$SPADS_REGISTRATION_EMAIL \
 	CMD_baseGamePort={{ spads_baseGamePort }} \
 	CMD_baseAutoHostPort={{ spads_baseAutoHostPort }} \
 	CMD_hostRegion={{ spads_hostRegion }} \


### PR DESCRIPTION
Move all secret like variables to secrets.env loaded for the unit process so they are not spread across more files. In the future it will be good to handle them even better using systemd-creds but that requires more work and I don't see any convenient ansible module for this yet.