### PR TITLE
Update restart.yaml to become:yes

### DIFF
--- a/engineupdate.yaml
+++ b/engineupdate.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Update SPADS engine
   hosts: all
+  become: yes
 #  remote_user: root
 
   tasks:

--- a/restart.yaml
+++ b/restart.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Restart SPADS
   hosts: all
+  become: yes
 #  remote_user: root
 
   tasks:


### PR DESCRIPTION
Otherwise it throws errors

`
TASK [Restart SPADS services] **************************************************************************************************
failed: [eu5] (item=pr-downloader.service) => {"ansible_loop_var": "item", "changed": false, "item": "pr-downloader.service", "msg": "Unable to start service pr-downloader.service: Failed to start pr-downloader.service: Connection timed out\nSee system logs and 'systemctl status pr-downloader.service' for details.\n"}
failed: [eu5] (item=spads_config_updater.service) => {"ansible_loop_var": "item", "changed": false, "item": "spads_config_updater.service", "msg": "Unable to start service spads_config_updater.service: Failed to start spads_config_updater.service: Connection timed out\nSee system logs and 'systemctl status spads_config_updater.service' for details.\n"}
failed: [eu5] (item=spads.service) => {"ansible_loop_var": "item", "changed": false, "item": "spads.service", "msg": "Unable to restart service spads.service: Failed to restart spads.service: Connection timed out\nSee system logs and 'systemctl status spads.service' for details.\n"}

`