### PR TITLE
Fix missing var on task name

### DIFF
--- a/roles/spads/tasks/swap.yaml
+++ b/roles/spads/tasks/swap.yaml
@@ -39,8 +39,9 @@
   ansible.builtin.command: swapon -a
   changed_when: false
 
-- name: Set swapiness to {{ swap_swappiness }}
+- name: Set swapiness
   become: yes
   ansible.builtin.sysctl:
     name: vm.swappiness
     value: "{{ swap_swappiness }}"
+  when: configure_swap | bool


### PR DESCRIPTION
otherwise, you would get the (harmless) error when running the dev playbook:

[WARNING]: Encountered 1 template error.
error 1 - 'swap_swappiness' is undefined
Origin: <snip>/roles/spads/tasks/swap.yaml:42:9