### PR TITLE
spads: regenerate game_modes.json after each game sync

### DIFF
--- a/roles/spads/defaults/main.yml
+++ b/roles/spads/defaults/main.yml
@@ -1,2 +1,7 @@
 ---
 # defaults file for spads
+
+# Map used by the headless game_modes.json regeneration boot (regen_game_modes.sh).
+# Must be a map that is synced on the host; the export reads no map data, it only
+# needs a valid map for the engine to start a game. Override per-host if needed.
+regen_game_modes_map: "Quicksilver Remake 1.24"

--- a/roles/spads/tasks/services.yaml
+++ b/roles/spads/tasks/services.yaml
@@ -9,6 +9,19 @@
     - clear_rapid_packages.sh
     - clear_replays.sh
 
+- name: Install game_modes regen script and startscript
+  become: yes
+  become_user: "{{ spads_username }}"
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: "{{ item.mode }}"
+    owner: spads
+    group: spads
+  with_items:
+    - { src: "regen_game_modes.sh.j2", dest: "{{ spads_install_path }}/regen_game_modes.sh", mode: "0755" }
+    - { src: "startscript_modes_export.txt.j2", dest: "{{ spads_install_path }}/var/regen/startscript_modes_export.txt", mode: "0644" }
+
 - name: Install systemd service
   ansible.builtin.template:
     src: "{{ item }}.j2"

--- a/roles/spads/templates/pr-downloader.service.j2
+++ b/roles/spads/templates/pr-downloader.service.j2
@@ -11,6 +11,8 @@ Type=oneshot
 Environment="PRD_RAPID_USE_STREAMER=false"
 Environment="PRD_RAPID_REPO_MASTER=https://repos-cdn.beyondallreason.dev/repos.gz"
 ExecStart=perl {{ spads_install_path }}/sequentialSpadsUnitsyncProcess.pl {{ spads_install_path }}/var {{ spads_install_path }}/pr-downloader --filesystem-writepath {{ spads_install_path }}/var/spring/data byar:test
+# Regenerate game_modes.json after each game sync (no-op unless the version changed).
+ExecStartPost=-{{ spads_install_path }}/regen_game_modes.sh
 StandardOutput=journal
 Restart=on-failure
 RestartSec=5s

--- a/roles/spads/templates/regen_game_modes.sh.j2
+++ b/roles/spads/templates/regen_game_modes.sh.j2
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regenerate game_modes.json for the SPADS ModeCommand plugin from the installed
+# BAR game archive. Hooked as ExecStartPost of pr-downloader.service so it runs
+# after each game sync, but skips the expensive headless boot unless the
+# byar:test game version actually changed.
+set -euo pipefail
+
+SPADS="{{ spads_install_path }}"
+ENGINE_DIR="{{ engine_dir }}"
+DATA="{{ spads_springDataDir }}"
+RAPID_TAG="byar:test"                          # [VERIFY] matches pr-downloader.service target
+MAP_NAME="{{ regen_game_modes_map }}"          # [VERIFY] this map must be synced on the host
+
+HEADLESS="${SPADS}/var/spring/${ENGINE_DIR}/spring-headless"   # [VERIFY] present in release
+REGEN_DIR="${SPADS}/var/regen"
+STARTSCRIPT_TMPL="${REGEN_DIR}/startscript_modes_export.txt"
+STARTSCRIPT="${REGEN_DIR}/startscript_modes_export.run.txt"
+OUT="${REGEN_DIR}/game_modes.json"             # write-dir output (widget writes game_modes.json)
+PLUGIN_JSON="${SPADS}/var/plugins/ModeCommand/game_modes.json"  # [VERIFY] where modecommand.py reads
+STATE_FILE="${REGEN_DIR}/.last_game_version"
+
+mkdir -p "${REGEN_DIR}"
+
+# Resolve the currently-installed byar:test version from rapid metadata.
+# versions.gz lines are: <tag>,<sdp_md5>,<depends>,<name>
+versions_file="$(find "${DATA}/rapid" -name versions.gz 2>/dev/null | head -n1 || true)"
+sdp=""; game_name=""
+if [[ -n "${versions_file}" ]]; then
+	line="$(zcat "${versions_file}" 2>/dev/null | awk -F, -v t="${RAPID_TAG}" '$1==t{print; exit}' || true)"
+	sdp="$(awk -F, '{print $2}' <<<"${line}")"
+	game_name="$(awk -F, '{print $4}' <<<"${line}")"
+fi
+
+# Cheap guard: nothing to do if the resolved version is unchanged.
+if [[ -n "${sdp}" && -f "${STATE_FILE}" && "$(cat "${STATE_FILE}")" == "${sdp}" && -f "${PLUGIN_JSON}" ]]; then
+	exit 0
+fi
+
+# Fall back to the rapid tag if we couldn't resolve the archive name.
+[[ -z "${game_name}" ]] && game_name="${RAPID_TAG}"   # [VERIFY] engine resolves rapid tag as GameType
+
+sed -e "s|@GAMETYPE@|${game_name}|" -e "s|@MAPNAME@|${MAP_NAME}|" \
+	"${STARTSCRIPT_TMPL}" > "${STARTSCRIPT}"
+
+rm -f "${OUT}"
+"${HEADLESS}" --isolation --write-dir "${REGEN_DIR}" "${STARTSCRIPT}"
+
+if [[ ! -f "${OUT}" ]]; then
+	echo "regen_game_modes: export produced no ${OUT}" >&2
+	exit 1
+fi
+
+# Replace the plugin's copy when the presets changed. No SPADS reload here: the
+# plugin re-reads game_modes.json on mtime change, and this runs as the
+# unprivileged spads user (cannot reload the service anyway).
+if [[ ! -f "${PLUGIN_JSON}" ]] || ! cmp -s "${OUT}" "${PLUGIN_JSON}"; then
+	install -D -m 0644 "${OUT}" "${PLUGIN_JSON}"
+fi
+
+[[ -n "${sdp}" ]] && echo "${sdp}" > "${STATE_FILE}"

--- a/roles/spads/templates/startscript_modes_export.txt.j2
+++ b/roles/spads/templates/startscript_modes_export.txt.j2
@@ -1,0 +1,32 @@
+# Headless one-shot startscript to regenerate game_modes.json from the installed
+# game archive. Boots spring-headless, enables the BAR "Game Modes JSON Export"
+# LuaUI widget (ships inside the game archive), runs /exportgamemodes, quits.
+# @GAMETYPE@ and @MAPNAME@ are substituted by regen_game_modes.sh at runtime.
+[GAME]
+{
+	MapName=@MAPNAME@;
+	GameType=@GAMETYPE@;
+	GameStartDelay=0;
+	StartPosType=0;
+	RecordDemo=0;
+	MyPlayerName=ModesExporter;
+	IsHost=1;
+	FixedRNGSeed=1;
+	[MODOPTIONS]
+	{
+		debugcommands=1:luaui enablewidget Game Modes JSON Export|2:exportgamemodes|3:quitforce;
+		deathmode=neverend;
+	}
+	[ALLYTEAM0]
+	{
+	}
+	[TEAM0]
+	{
+		allyteam=0;
+		teamleader=0;
+	}
+	[PLAYER0]
+	{
+		team=0;
+	}
+}


### PR DESCRIPTION
This mirrors what unitDefs was doing by introducing a widget that exports json from BAR declarative mode files. Adds a version-guarded headless export (regen_game_modes.sh + a one-shot startscript) hooked as pr-downloader.service w/ExecStartPost, so the ModeCommand plugin's game_modes.json is regenerated from the synced game archive when the byar:test version changes.

I've used Ansible a lot in the past, this LGTM and I tested it every way that I could think to in local containers. Logic reviewed and verified locally (ansible --syntax-check, template render, regen orchestration with a stub engine, and a privileged systemd container exercising the ExecStartPost trigger end to end).

AI assistance: drafted with Claude Code. Full acceptance on an engine_testing host is still pending and should accompany the PR per AI_POLICY. I don't have access to this infrastructure, so not entirely sure how to do that.

Part of [Sharing Modes](https://github.com/beyond-all-reason/BYAR-Chobby/issues/1040)