### PR TITLE
update zabbix server ip

### DIFF
--- a/group_vars/prod/vars.yaml
+++ b/group_vars/prod/vars.yaml
@@ -21,7 +21,7 @@ mapSyncer_healthcheckUrl: https://hc-ping.com/{{ vault_healthchecksioPingKey }}/
 
 configure_zabbix_agent: true
 zabbix_psk: "{{ vault_zabbix_psk }}"
-zabbix_server: 192.3.148.174
+zabbix_server: 108.174.58.110
 
 configure_monitoring: true
 monitoring_write_instance_dev: false


### PR DESCRIPTION
Racknerd changed the IP of the Zabbix server because some hardware was failing. This updates the IP to the new server. I know this isn't the direction we are going, or even want to go but I figured I'd submit the fix anyway. We could always change the alerts of what Zabbix sends out or what it monitors. For example only host down alerts and expiring certs or something similar.